### PR TITLE
Manage uses SQLAlchemy to get the list of tables instead of a SQL query.

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -254,10 +254,10 @@ def create_all():
     app = create_app(parse_options())
     log = logging.getLogger(__name__)
     with app.app_context():
-        tables_before = db.engine.table_name()
+        tables_before = set(db.engine.table_names())
         db.create_all()
-        tables_after = db.engine.table_name()
-    created_tables = set(tables_after) - set(tables_before)
+        tables_after = set(db.engine.table_names())
+    created_tables = tables_after - tables_before
     for table in created_tables:
         log.info('Created table: {}'.format(table))
 

--- a/manage.py
+++ b/manage.py
@@ -254,10 +254,10 @@ def create_all():
     app = create_app(parse_options())
     log = logging.getLogger(__name__)
     with app.app_context():
-        tables_before = {t[0] for t in db.session.execute('SHOW TABLES')}
+        tables_before = db.engine.table_name()
         db.create_all()
-        tables_after = {t[0] for t in db.session.execute('SHOW TABLES')}
-    created_tables = tables_after - tables_before
+        tables_after = db.engine.table_name()
+    created_tables = set(tables_after) - set(tables_before)
     for table in created_tables:
         log.info('Created table: {}'.format(table))
 


### PR DESCRIPTION
I structured a Flask app using this example. However, I'm using PostgreSQL instead of MySQL. The raw query in manage.py doesn't work for my database, but SQLAlchemy provides an abstraction to get database tables for all supported databases.

This patch asks SQLAlchemy for database tables instead of the database directly.