### PR TITLE
Fixed README.md badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,8 @@ several aspects of the project.
 For information on how to deploy this application to different production environments, visit
 [the project's wiki](https://github.com/Robpol86/Flask-Large-Application-Example/wiki).
 
-[![Build Status](https://travis-ci.org/Robpol86/Flask-Large-Application-Example.svg?branch=master)]
-(https://travis-ci.org/Robpol86/Flask-Large-Application-Example)
-[![Coverage Status](https://img.shields.io/coveralls/Robpol86/Flask-Large-Application-Example.svg)]
-(https://coveralls.io/r/Robpol86/Flask-Large-Application-Example)
+[![Build Status](https://travis-ci.org/Robpol86/Flask-Large-Application-Example.svg?branch=master)](https://travis-ci.org/Robpol86/Flask-Large-Application-Example)
+[![Coverage Status](https://img.shields.io/coveralls/Robpol86/Flask-Large-Application-Example.svg)](https://coveralls.io/r/Robpol86/Flask-Large-Application-Example)
 
 ## Features
 


### PR DESCRIPTION
I fixed the broken Markdown links for the build and coverage badges because it was bugging me. You still have a build failing due to missing `CELERY_BROKER_URL` though, but I don't know how to fix that.